### PR TITLE
Fix React/D3 Provider files

### DIFF
--- a/src/D3Provider.js
+++ b/src/D3Provider.js
@@ -1,3 +1,7 @@
-var d3 = window.d3 || require('d3');
+if(typeof require === 'function') {
+  module.exports = require('d3');
+}
 
-module.exports = d3;
+else {
+  module.exports = window.d3;
+}

--- a/src/ReactProvider.js
+++ b/src/ReactProvider.js
@@ -1,3 +1,7 @@
-var React = window.React || require('react');
+if(typeof require === 'function') {
+  module.exports = require('d3');
+}
 
-module.exports = React;
+else {
+  module.exports = window.d3;
+}


### PR DESCRIPTION
Currently they are testing against `window` object first, which is `undefined` and will cause a key lookup fail when running in a node environment.