### PR TITLE
Resets xExtentDomain when Brush background is clicked.

### DIFF
--- a/src/Brush.jsx
+++ b/src/Brush.jsx
@@ -168,7 +168,7 @@ let Brush = React.createClass({
 		range[1] -= size;
 
 		let min = Math.max(range[0], Math.min(range[1], point[0]));
-		this.setState({xExtent: [min, min + size]});
+		this.setState({xExtent: [min, min + size], xExtentDomain: null});
 	},
 
 	// TODO: use constants instead of strings


### PR DESCRIPTION
When clicking on the background of the Brush, the extent wouldn't stay at the clicked spot once onMouseUp was fired. The xExtentDomain was not being reset with the onMouseDown event so it would move the extent back to its original position. This PR resets the xExtentDomain so that the extent stays put.