### PR TITLE
added extra param to tooltipHtml prop callback invocation in Areachart component

### DIFF
--- a/src/AreaChart.jsx
+++ b/src/AreaChart.jsx
@@ -119,7 +119,7 @@ let AreaChart = React.createClass({
 		let yValue = y(values(d[yIndex])[xIndex]);
 		let yValueCumulative = y0(values(d[d.length - 1])[xIndex]) + y(values(d[d.length - 1])[xIndex]);
 
-		return this.props.tooltipHtml(yValue, yValueCumulative);
+		return this.props.tooltipHtml(yValue, yValueCumulative, xIndex);
 	},
 
 	render() {


### PR DESCRIPTION
I needed to create a custom tooltip on hover for areachart. But needed to access the data x value for the hovered column. I added xIndex as the third parameter to `this.props.tooltipHtml` invocation. Will not break anything existing but give extra data to work with for people trying to implement custom tooltips.