### PR TITLE
typo fix in example.html

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -196,8 +196,8 @@ var SomeComponent = React.createClass({
 	React.render(<PieChart
 					data={data}
 					width={600}
-					height={400} m
-					argin={{top: 10, bottom: 10, left: 100, right: 100}}
+					height={400} 
+					margin={{top: 10, bottom: 10, left: 100, right: 100}}
 					tooltipHtml={tooltipPie}
 					sort={null}
 					/>,


### PR DESCRIPTION
"margin" attribute name in the pie chart example used to have the "m" on the previous line. The "margin" attribute name is now all on the same line.

![image](https://cloud.githubusercontent.com/assets/9893865/9014292/65935b30-3776-11e5-86cf-66f3fd140fb4.png)


