### PR TITLE
Adding option to add custom SVG elements

### DIFF
--- a/src/AreaChart.jsx
+++ b/src/AreaChart.jsx
@@ -196,6 +196,7 @@ let AreaChart = React.createClass({
 			width={innerWidth}
 			{...yAxis}
 				/>
+				{ this.props.children }
 				</Chart>
 
 				<Tooltip

--- a/src/BarChart.jsx
+++ b/src/BarChart.jsx
@@ -138,6 +138,7 @@ let BarChart = React.createClass({
 			width={innerWidth}
 			{...yAxis}
 				/>
+				{ this.props.children }
 				</Chart>
 
 				<Tooltip

--- a/src/Brush.jsx
+++ b/src/Brush.jsx
@@ -135,6 +135,7 @@ let Brush = React.createClass({
 			width={this._innerWidth}
 			{...this.props.xAxis}
 				/>
+					{ this.props.children }
 				</Chart>
 				</div>
 		);

--- a/src/LineChart.jsx
+++ b/src/LineChart.jsx
@@ -274,7 +274,7 @@ let LineChart = React.createClass({
 			zero={xIntercept}
 			{...yAxis}
 				/>
-
+				{ this.props.children }
 				{tooltipSymbol}
 
 				</Chart>

--- a/src/PieChart.jsx
+++ b/src/PieChart.jsx
@@ -218,6 +218,7 @@ let PieChart = React.createClass({
 			onMouseLeave={this.onMouseLeave}
 				/>
 				</g>
+				{ this.props.children }
 				</Chart>
 
 				<Tooltip

--- a/src/ScatterPlot.jsx
+++ b/src/ScatterPlot.jsx
@@ -155,6 +155,7 @@ let ScatterPlot = React.createClass({
 			onMouseEnter={this.onMouseEnter}
 			onMouseLeave={this.onMouseLeave}
 				/>
+				{ this.props.children }
 				</Chart>
 
 				<Tooltip


### PR DESCRIPTION
Thank you for this.

I needed to add a custom overlay to one of the carts but found no way to add SVG elements to the charts easily without interfering with the tooltips.

After this change you can do something like:

```
<BarChart {...props}>
	<path style={{ fill: "none", "stroke": "#444", strokeWidth: "1.5px"}} d="M0,0L0,100"></path>
</BarChart>

```
To add an extra line to the graph for example. Maybe that's something useful for others too...