### PR TITLE
Make lineClip elements unique regarding their size

### DIFF
--- a/src/LineChart.jsx
+++ b/src/LineChart.jsx
@@ -34,6 +34,8 @@ let DataSet = React.createClass({
 			 onMouseEnter,
 			 onMouseLeave} = this.props;
 
+		let sizeId = width + 'x' + height;
+
 		let lines = data.map((stack, index) => {
 			return (
 					<Path
@@ -47,7 +49,7 @@ let DataSet = React.createClass({
 				data={values(stack)}
 				onMouseEnter={onMouseEnter}
 				onMouseLeave={onMouseLeave}
-				style={{clipPath: 'url(#lineClip)'}}
+				style={{clipPath: 'url(#lineClip_'+sizeId+')'}}
 					/>
 			);
 		});
@@ -59,7 +61,7 @@ let DataSet = React.createClass({
 		let rect = React.renderToString(<rect width={width} height={height}/>);
 		return (
 				<g>
-				<g dangerouslySetInnerHTML={{__html: `<defs><clipPath id="lineClip">${rect}`}}/>
+				<g dangerouslySetInnerHTML={{__html: `<defs><clipPath id="lineClip_"+sizeId>${rect}`}}/>
 				{lines}
 				<rect width={width} height={height} fill={'none'} stroke={'none'} style={{pointerEvents: 'all'}}
 			onMouseMove={ evt => { onMouseEnter(evt, data); } }


### PR DESCRIPTION
This allows to have multiple charts on the same page, each having their unique lineClip element (regarding their size). Should fix issue #32 on Chrome.