### PR TITLE
moving react to a peerdependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
 	"url": "https://github.com/codesuki/react-d3-components/issues"
   },
   "homepage": "https://github.com/codesuki/react-d3-components",
+  "peerDependencies": {    
+  "react": "^0.13.1"
+  },
   "dependencies": {
-	"d3": "^3.5.3",
-	"react": "^0.13.1"
+	"d3": "^3.5.3"
   },
   "devDependencies": {
 	"babel": "^4.6.4",


### PR DESCRIPTION
fixes issues #29 and #39 by moving react to a peerdependency so that 2 versions of react are not installed