### PR TITLE
add tickFormat as prop to BarChart

### DIFF
--- a/src/BarChart.jsx
+++ b/src/BarChart.jsx
@@ -142,7 +142,8 @@ let BarChart = React.createClass({
 			 xAxis,
 			 yAxis,
 			 groupedBars,
-			 colorByLabel} = this.props;
+			 colorByLabel,
+			 tickFormat} = this.props;
 
 		let [data,
 			 innerWidth,
@@ -179,6 +180,7 @@ let BarChart = React.createClass({
 			scale={xScale}
 			height={innerHeight}
 			width={innerWidth}
+			tickFormat={tickFormat}
 			{...xAxis}
 				/>
 
@@ -188,6 +190,7 @@ let BarChart = React.createClass({
 			scale={yScale}
 			height={innerHeight}
 			width={innerWidth}
+			tickFormat={tickFormat}
 			{...yAxis}
 				/>
 				{ this.props.children }


### PR DESCRIPTION
### Bug
Currently there is no way to pass in a custom tickFormat function to BarChart unless you include it in your x or y scale. However, Axis is set up to check if a tickFormat prop is defined independent of scale.

### Fix
Allow BarChart to receive a tickFormat prop. This allows you to customize your tick labels without having to worry about figuring out what the rest of xScale entails. 

### Tested
I tested this with a graph I've been working on. I only wanted to show every 4th tick label, which I can now do by passing in my own function as a tickFormat prop to BarChart. If no tickFormat prop is defined, business continues as usual.

<img width="818" alt="screenshot 2016-02-15 21 30 17" src="https://cloud.githubusercontent.com/assets/1342734/13067977/590c7fac-d42b-11e5-8515-f4367d0e3c08.png">
