### PR TITLE
Fix placement of axis label when axis' orientation is on the right.

### DIFF
--- a/src/Axis.jsx
+++ b/src/Axis.jsx
@@ -107,7 +107,7 @@ let Axis = React.createClass({
             textAnchor = sign < 0 ? "end" : "start";
             d = `M${sign * outerTickSize}, ${range[0]}H0V${range[1]}H${sign * outerTickSize}`;
 
-            labelElement = <text className={`${className} label`} textAnchor={"end"} y={6} dy={".75em"} transform={"rotate(-90)"}>{label}</text>;
+            labelElement = <text className={`${className} label`} textAnchor={"end"} y={6} dy={orientation === "left" ? ".75em" : "-.75em"} transform={"rotate(-90)"}>{label}</text>;
         }
 
         let tickElements = ticks.map((tick, index) => {

--- a/src/Axis.jsx
+++ b/src/Axis.jsx
@@ -107,7 +107,7 @@ let Axis = React.createClass({
             textAnchor = sign < 0 ? "end" : "start";
             d = `M${sign * outerTickSize}, ${range[0]}H0V${range[1]}H${sign * outerTickSize}`;
 
-            labelElement = <text className={`${className} label`} textAnchor={"end"} y={6} dy={orientation === "left" ? ".75em" : "-.75em"} transform={"rotate(-90)"}>{label}</text>;
+            labelElement = <text className={`${className} label`} textAnchor={"end"} y={6} dy={orientation === "left" ? ".75em" : "-1.25em"} transform={"rotate(-90)"}>{label}</text>;
         }
 
         let tickElements = ticks.map((tick, index) => {


### PR DESCRIPTION
If the axis is on the right, the label ends up on top of the tick marks.  With this check, it'll move it .75em in the appropriate direction.  Built and test on my local environment and it looks good.