### PR TITLE
Change the render order of the Axes in LineChart

### DIFF
--- a/src/LineChart.jsx
+++ b/src/LineChart.jsx
@@ -258,18 +258,6 @@ const LineChart = React.createClass({
         return (
             <div>
                 <Chart height={height} width={width} margin={margin}>
-                    <DataSet
-                        height={innerHeight}
-                        width={innerWidth}
-                        data={data}
-                        line={line}
-                        colorScale={colorScale}
-                        values={values}
-                        label={label}
-                        onMouseEnter={this.onMouseEnter}
-                        onMouseLeave={this.onMouseLeave}
-                        {...stroke}
-                    />
                     <Axis
                         className="'x axis'"
                         orientation="bottom"
@@ -287,6 +275,18 @@ const LineChart = React.createClass({
                         width={innerWidth}
                         zero={xIntercept}
                         {...yAxis}
+                    />                
+                    <DataSet
+                        height={innerHeight}
+                        width={innerWidth}
+                        data={data}
+                        line={line}
+                        colorScale={colorScale}
+                        values={values}
+                        label={label}
+                        onMouseEnter={this.onMouseEnter}
+                        onMouseLeave={this.onMouseLeave}
+                        {...stroke}
                     />
                     {this.props.children}
                     {tooltipSymbol}


### PR DESCRIPTION
In the LineChart component, the Axes should render before the DataSet so that axis tick paths (if configured to span across the chart) don't cover up any paths rendered by the DataSet. This change will also make the render order consistent with the ScatterPlot component, in which Axes are rendered first.
This affects the look/aesthetics of the graph, but also affects tooltip rendering; a tick line intersecting a point on the graph will cause the tooltip to hide if the cursor is placed on the tick line rather than the data line.
![screen shot 2016-08-22 at 11 08 14 am](https://cloud.githubusercontent.com/assets/1175555/17862108/72bc55ea-6859-11e6-9e31-66422284b943.png)
