### PR TITLE
Update examples and docs about tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,9 @@ var SomeComponent = React.createClass({
 You can provide a callback to every chart that will return html for the tooltip.
 Depending on the type of chart the callback will receive different parameters that are useful.
 
-* Bar Chart: x, y0, y of the hovered bar and the total bar height in case of a stacked bar chart.
+* Bar Chart: label is the first parameter. y0, y of the hovered bar and the total bar height in case of a stacked bar chart.
 * Scatter Plot: x, y of the hovered point.
-* Pie Chart: x, y, of the hovered wedge.
+* Pie Chart: label is the first parameter. y of the hovered wedge.
 * Area Chart: closest y value to the cursor of the area under the mouse and the cumulative y value in case of a stacked area chart. x value is the third parameter. label is the fourth parameter.
 
 Example Scatter Plot:

--- a/example/index.html
+++ b/example/index.html
@@ -115,7 +115,7 @@
         );
 
         var tooltip = function(x, y0, y, total) {
-        return y.toString();
+        return x + " " + y.toString();
         };
 
         var tooltipScatter = function(x, y) {
@@ -123,7 +123,7 @@
         };
 
         var tooltipPie = function(x, y) {
-        return y.toString();
+        return x + ": " + y.toString();
         };
 
         var tooltipArea = function(y, cumulative, x, label) {


### PR DESCRIPTION
resolve #78 

I just updated README and example for tooltip labels.

<img width="402" alt="2018-03-19 5 06 54" src="https://user-images.githubusercontent.com/278473/37584222-01fbb1ee-2b98-11e8-94e0-7f0009382ed3.png">
<img width="587" alt="2018-03-19 5 07 05" src="https://user-images.githubusercontent.com/278473/37584223-02295112-2b98-11e8-92da-e9e7721fb578.png">
